### PR TITLE
Bug fix for Fast5_to_seq_summary for directories with 1 fast5 file

### DIFF
--- a/pycoQC/Fast5_to_seq_summary.py
+++ b/pycoQC/Fast5_to_seq_summary.py
@@ -169,13 +169,15 @@ class Fast5_to_seq_summary ():
         logger.debug ("[READER] Start listing fast5 files")
         try:
             # Load an input queue with fast5 file path
+            found_fast5_file = False
             for i, fast5_fn in enumerate(recursive_file_gen (dir=self.fast5_dir, ext="fast5")):
                 if self.max_fast5 and i == self.max_fast5:
                     break
                 in_q.put(fast5_fn)
+                found_fast5_file = True
 
             # Raise error is no file found
-            if i == 0:
+            if not found_fast5_file:
                 raise pycoQCError ("No valid fast5 files found in indicated folder")
 
             logger.debug ("[READER] Add a total of {} files to input queue".format(i+1))


### PR DESCRIPTION
Currently, the code looks at the enumerate index `i` to see if a fast5 file was found in the given directory. However, if a directory does not have any files in it, then the enumeration loop won't get started and the `i` variable will actually be unbound, so the code as written would raise an `UnboundLocalError`. If there is a single fast5 file in the directory, then `i` will be valid, but it will be `==0`, causing the current code to error saying that no fast5 files were found.

I've updated the logic to use a simple flag to indicate when we have actually inserted a fast5 file into the Queue during this loop.