### PR TITLE
Fixed broken links from usage.md

### DIFF
--- a/docs/Barcode_split/usage.md
+++ b/docs/Barcode_split/usage.md
@@ -8,11 +8,11 @@
 
 ### Jupyter API
 
-* [Barcode_split API usage notebook](Barcode_split/API_usage)
+* [Barcode_split API usage notebook](API_usage.ipynb)
 
 ### Shell CLI
 
-* [Barcode_split CLI usage notebook](Barcode_split/CLI_usage)
+* [Barcode_split CLI usage notebook](CLI_usage.ipynb)
 
 
 ## IO and options

--- a/docs/Fast5_to_seq_summary/usage.md
+++ b/docs/Fast5_to_seq_summary/usage.md
@@ -8,11 +8,11 @@ In case you do not have access to a summary sequencing file, pycoQC comes with `
 
 ### Jupyter API
 
-* [pycoQC API usage notebook](Fast5_to_seq_summary/API_usage)
+* [pycoQC API usage notebook](API_usage.ipynb)
 
 ### Shell CLI
 
-* [pycoQC CLI usage notebook](Fast5_to_seq_summary/CLI_usage)
+* [pycoQC CLI usage notebook](CLI_usage.ipynb)
 
 
 ## Input files and options

--- a/docs/pycoQC/usage.md
+++ b/docs/pycoQC/usage.md
@@ -10,7 +10,7 @@ The [Jupyter Notebook](https://jupyter.org/) is a fantastic tool that can be use
 
 One of the specificity of pycoQC is to have a rich python API meant to be used directly inside a Jupyter notebook. The pycoQC API for Jupyter is very flexible and allows you to explore your nanopore data interactively and in more depth than with the command line interface.
 
-* [pycoQC API usage notebook](pycoQC/API_usage)
+* [pycoQC API usage notebook](API_usage.ipynb)
 
 An online live version of the usage notebook served by MyBinder is also available to familiarize with the package API:
 
@@ -20,7 +20,7 @@ An online live version of the usage notebook served by MyBinder is also availabl
 
 On top of the jupyter interface, pycoQC also comes with a command line interface that can generate a beautiful HTML formatted report containing interactive D3.js plots.
 
-* [pycoQC CLI usage notebook](pycoQC/CLI_usage)
+* [pycoQC CLI usage notebook](CLI_usage.ipynb)
 
 ## Input files and options
 


### PR DESCRIPTION
Fixed the broken links to each of the jupyter notebooks describing CLI and API usage in the pycoQC usage, barcode_split usage, and Fast5_to_seq_summary usage.